### PR TITLE
fix predict() function error about image_dim_ordering

### DIFF
--- a/boss_train.py
+++ b/boss_train.py
@@ -151,9 +151,12 @@ class Model(object):
         self.model = load_model(file_path)
 
     def predict(self, image):
-        if image.shape != (1, 3, IMAGE_SIZE, IMAGE_SIZE):
+        if K.image_dim_ordering() == 'th' and image.shape != (1, 3, IMAGE_SIZE, IMAGE_SIZE):
             image = resize_with_pad(image)
             image = image.reshape((1, 3, IMAGE_SIZE, IMAGE_SIZE))
+        elif K.image_dim_ordering() == 'tf' and image.shape != (1, IMAGE_SIZE, IMAGE_SIZE, 3):
+            image = resize_with_pad(image)
+            image = image.reshape((1, IMAGE_SIZE, IMAGE_SIZE, 3))
         image = image.astype('float32')
         image /= 255
         result = self.model.predict_proba(image)


### PR DESCRIPTION
add the verification about image_dim_ordering when predicting the model